### PR TITLE
Add resize method to heatmap API

### DIFF
--- a/examples/heatmap.html
+++ b/examples/heatmap.html
@@ -18,6 +18,7 @@
     <body>
         <div id="heatmap"></div>
         <button id="cluster">Cluster!</button>
+        <button id="resize">Resize!</button>
 
         <script>
             const amountOfRows = 80;
@@ -47,6 +48,11 @@
                 document.getElementById("cluster")
                     .addEventListener("click", () => {
                         heatmap.cluster();
+                    });
+
+                document.getElementById("resize")
+                    .addEventListener("click", () => {
+                        heatmap.resize(1000, 1000);
                     });
             }
         </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "unipept-heatmap",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unipept-heatmap",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.8",
   "description": "HeatMap built for the Unipept project. See http://unipept.ugent.be for more information. This HeatMap supports UPGMA-clustering and MOLO-reordering.",
   "main": "dist/bundle.js",
   "typings": "./types",

--- a/src/heatmap/Heatmap.ts
+++ b/src/heatmap/Heatmap.ts
@@ -265,6 +265,7 @@ export default class Heatmap {
         this.visElement.attr("height", this.pixelRatio * newHeight);
         this.visElement.attr("width", this.pixelRatio * newWidth);
         this.visElement.attr("style", `width: ${this.settings.width}px; height: ${this.settings.height}px`);
+        this.context.scale(this.pixelRatio, this.pixelRatio);
 
         this.originalViewPort = {
             xTop: 0,

--- a/types/heatmap/Heatmap.d.ts
+++ b/types/heatmap/Heatmap.d.ts
@@ -20,6 +20,7 @@ export default class Heatmap {
     private highlightedRow;
     private highlightedColumn;
     private pixelRatio;
+    private lastZoomStatus;
     constructor(elementIdentifier: HTMLElement, values: (number | HeatmapValue)[][], rowLabels: string[], columnLabels: string[], options?: HeatmapSettings);
     private fillOptions;
     /**
@@ -33,7 +34,7 @@ export default class Heatmap {
      * denotes that the clustering is performed on the rows only.
      */
     cluster(toCluster?: "all" | "columns" | "rows" | "none"): Promise<void>;
-    setFullScreen(fullscreen: boolean): void;
+    resize(newWidth: number, newHeight: number): void;
     /**
      * Convert the heatmap to an SVG-string that can easily be downloaded as a valid SVG-file. Note that the current
      * positioning and zooming level of the heatmap will not be taken into account (but clustering will!).


### PR DESCRIPTION
This PR adds a new method "resize" to the heatmap API of this package. This method allows you to change the dimensions of the heatmap without needing to create a new one (or resetting the current heatmap, which will trigger the animations again).